### PR TITLE
Move quick add button onto product image

### DIFF
--- a/assets/quick-add.css
+++ b/assets/quick-add.css
@@ -404,3 +404,24 @@ quick-add-bulk .quantity__input {
 .quantity__input-disabled {
   pointer-events: none;
 }
+
+.quick-add--overlay {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  margin: 0;
+  z-index: 2;
+}
+
+.quick-add--overlay .quick-add__submit {
+  padding: 0;
+  min-width: 0;
+  width: 4rem;
+  height: 4rem;
+  border-radius: 50%;
+}
+
+.quick-add--overlay .quick-add__submit svg {
+  width: 1.8rem;
+  height: 1.8rem;
+}

--- a/locales/cs.schema.json
+++ b/locales/cs.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Žádné",
             "option_2": "Standardní",
-            "option_3": "Hromadné"
+            "option_3": "Hromadné",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/da.schema.json
+++ b/locales/da.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Ingen",
             "option_2": "Standard",
-            "option_3": "Masse"
+            "option_3": "Masse",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Keine",
             "option_2": "Standard",
-            "option_3": "Sammelaktion"
+            "option_3": "Sammelaktion",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -449,11 +449,11 @@
           "label": "Change every"
         },
         "heading_utilities": {
-         "content": "Utilities"
+          "content": "Utilities"
         },
         "paragraph": {
           "content": "Appear only on large screens"
-        },                     
+        },
         "show_social": {
           "label": "Social media icons",
           "info": "[Manage social accounts](/editor?context=theme&category=social%20media)"
@@ -517,7 +517,7 @@
         },
         "header_layout": {
           "content": "Layout"
-        },            
+        },
         "desktop_layout": {
           "label": "Layout",
           "options__1": {
@@ -608,9 +608,9 @@
           "default": "Collections",
           "label": "Heading"
         },
-         "header_layout": {
-        "content": "Layout"
-        },        
+        "header_layout": {
+          "content": "Layout"
+        },
         "image_ratio": {
           "label": "Image ratio",
           "options__1": {
@@ -692,17 +692,17 @@
           "label": "Heading"
         },
         "layout_header": {
-        "content": "Layout"
+          "content": "Layout"
         },
         "text_header": {
-        "content": "Text"
-        },        
+          "content": "Text"
+        },
         "blog": {
           "label": "Blog"
         },
         "post_limit": {
           "label": "Post count"
-        }, 
+        },
         "columns_desktop": {
           "label": "Columns"
         },
@@ -728,7 +728,7 @@
       "name": "Featured collection",
       "settings": {
         "header_text": {
-        "content": "Text"
+          "content": "Text"
         },
         "title": {
           "label": "Heading",
@@ -756,8 +756,8 @@
           "content": "Collection layout"
         },
         "header_mobile": {
-        "content": "Mobile layout"
-        },                 
+          "content": "Mobile layout"
+        },
         "collection": {
           "label": "Collection"
         },
@@ -1177,7 +1177,7 @@
           "options__4": {
             "label": "Large"
           }
-          },
+        },
         "content": {
           "content": "Content"
         },
@@ -1282,9 +1282,9 @@
         "buttons": {
           "name": "Buttons",
           "settings": {
-          "header_1":{
-          "content": "Button 1"
-          },
+            "header_1": {
+              "content": "Button 1"
+            },
             "button_label_1": {
               "label": "Label",
               "info": "Leave blank to hide",
@@ -1296,7 +1296,7 @@
             "button_style_secondary_1": {
               "label": "Outline style"
             },
-            "header_2":{
+            "header_2": {
               "content": "Button 2"
             },
             "button_label_2": {
@@ -1320,12 +1320,12 @@
     "image-with-text": {
       "name": "Image with text",
       "settings": {
-      "header": {
-      "content": "Content"
-      },
-      "header_colors": {
-      "content": "Colors" 
-      },
+        "header": {
+          "content": "Content"
+        },
+        "header_colors": {
+          "content": "Colors"
+        },
         "image": {
           "label": "Image"
         },
@@ -1496,15 +1496,15 @@
         "image": {
           "label": "Image"
         },
-        "header":{
-        "content": "Image"
+        "header": {
+          "content": "Image"
         },
-        "header_2":{
-        "content": "Content"
+        "header_2": {
+          "content": "Content"
         },
-        "header_3":{
-        "content": "Colors"
-        },        
+        "header_3": {
+          "content": "Colors"
+        },
         "image_height": {
           "options__1": {
             "label": "Adapt to image"
@@ -1827,7 +1827,8 @@
           "options": {
             "option_1": "None",
             "option_2": "Standard",
-            "option_3": "Bulk"
+            "option_3": "Bulk",
+            "option_4": "Overlay"
           }
         },
         "columns_mobile": {
@@ -2295,7 +2296,7 @@
             },
             "pairing_2": {
               "label": "Pairing 2"
-            },            
+            },
             "icon_2": {
               "label": "Icon"
             },
@@ -2307,8 +2308,8 @@
               "default": "Heading"
             },
             "pairing_3": {
-            "label": "Pairing 3"
-            },             
+              "label": "Pairing 3"
+            },
             "icon_3": {
               "label": "Icon"
             },
@@ -2429,7 +2430,7 @@
           "options__2": {
             "label": "2"
           }
-        },        
+        },
         "image_ratio": {
           "label": "Image ratio",
           "options__1": {
@@ -2481,10 +2482,10 @@
         },
         "header_layout": {
           "content": "Layout"
-        },                            
+        },
         "header_button": {
           "content": "Button"
-        }, 
+        },
         "image_width": {
           "label": "Width",
           "options__1": {
@@ -2691,7 +2692,7 @@
         },
         "content_header": {
           "content": "Content"
-        },        
+        },
         "desktop_content_alignment": {
           "options__1": {
             "label": "Left"
@@ -2923,8 +2924,8 @@
           "name": "Buttons",
           "settings": {
             "header_button1": {
-            "content": "Button 1"
-            }, 
+              "content": "Button 1"
+            },
             "button_label_1": {
               "label": "Label",
               "info": "Leave blank to hide",
@@ -2938,7 +2939,7 @@
             },
             "header_button2": {
               "content": "Button 2"
-            },             
+            },
             "button_label_2": {
               "label": "Label",
               "info": "Leave label blank to hide"
@@ -3078,7 +3079,7 @@
               "default": "Tell your brand's story through images"
             },
             "header_button": {
-            "content": "Button"      
+              "content": "Button"
             },
             "button_label": {
               "label": "Label",
@@ -3092,7 +3093,7 @@
               "label": "Outline style"
             },
             "box_align": {
-              "label": "Content position",              
+              "label": "Content position",
               "options__1": {
                 "label": "Top left"
               },
@@ -3122,7 +3123,7 @@
               }
             },
             "header_layout": {
-            "content": "Layout"                 
+              "content": "Layout"
             },
             "show_text_box": {
               "label": "Container"
@@ -3143,11 +3144,11 @@
               "label": "Overlay opacity"
             },
             "header_text": {
-            "content": "Text"      
+              "content": "Text"
             },
             "header_colors": {
-            "content": "Colors"                 
-            },            
+              "content": "Colors"
+            },
             "text_alignment_mobile": {
               "label": "Mobile content alignment",
               "options__1": {
@@ -3208,8 +3209,8 @@
           "label": "Container color scheme"
         },
         "section_color_scheme": {
-        "label": "Section color scheme"
-        },        
+          "label": "Section color scheme"
+        },
         "open_first_collapsible_row": {
           "label": "Open first row"
         },

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Ninguno",
             "option_2": "Estándar",
-            "option_3": "Masivo"
+            "option_3": "Masivo",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/fi.schema.json
+++ b/locales/fi.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Ei ole",
             "option_2": "Vakio",
-            "option_3": "Erä"
+            "option_3": "Erä",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Aucun",
             "option_2": "Standard",
-            "option_3": "En gros"
+            "option_3": "En gros",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Nessuna",
             "option_2": "Standard",
-            "option_3": "Blocco"
+            "option_3": "Blocco",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/ja.schema.json
+++ b/locales/ja.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "なし",
             "option_2": "スタンダード",
-            "option_3": "一括"
+            "option_3": "一括",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/ko.schema.json
+++ b/locales/ko.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "없음",
             "option_2": "표준",
-            "option_3": "대량"
+            "option_3": "대량",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/nb.schema.json
+++ b/locales/nb.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Ingen",
             "option_2": "Standard",
-            "option_3": "Bulk"
+            "option_3": "Bulk",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/nl.schema.json
+++ b/locales/nl.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Geen",
             "option_2": "Standaard",
-            "option_3": "Bulk"
+            "option_3": "Bulk",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/pl.schema.json
+++ b/locales/pl.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Brak",
             "option_2": "Standard",
-            "option_3": "Zbiorczo"
+            "option_3": "Zbiorczo",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Nenhum",
             "option_2": "Padrão",
-            "option_3": "Em massa"
+            "option_3": "Em massa",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/pt-PT.schema.json
+++ b/locales/pt-PT.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Nenhum(a)",
             "option_2": "Padrão",
-            "option_3": "Em massa"
+            "option_3": "Em massa",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/sv.schema.json
+++ b/locales/sv.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Ingen",
             "option_2": "Standard",
-            "option_3": "Bulk"
+            "option_3": "Bulk",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/th.schema.json
+++ b/locales/th.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "ไม่มี",
             "option_2": "มาตรฐาน",
-            "option_3": "หลายรายการ"
+            "option_3": "หลายรายการ",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/tr.schema.json
+++ b/locales/tr.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "Yok",
             "option_2": "Standart",
-            "option_3": "Toplu"
+            "option_3": "Toplu",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/zh-CN.schema.json
+++ b/locales/zh-CN.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "无",
             "option_2": "标准",
-            "option_3": "批量"
+            "option_3": "批量",
+            "option_4": "Overlay"
           }
         }
       }

--- a/locales/zh-TW.schema.json
+++ b/locales/zh-TW.schema.json
@@ -1523,7 +1523,8 @@
           "options": {
             "option_1": "無",
             "option_2": "標準",
-            "option_3": "大量"
+            "option_3": "大量",
+            "option_4": "Overlay"
           }
         }
       }

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -13,7 +13,7 @@
   <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
 {%- endunless -%}
 
-{%- if section.settings.quick_add == 'standard' -%}
+{%- if section.settings.quick_add == 'standard' or section.settings.quick_add == 'overlay' -%}
   <script src="{{ 'quick-add.js' | asset_url }}" defer="defer"></script>
 {%- endif -%}
 

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -10,7 +10,7 @@
   {{ 'quick-add.css' | asset_url | stylesheet_tag }}
 {%- endunless -%}
 
-{%- if section.settings.quick_add == 'standard' -%}
+{%- if section.settings.quick_add == 'standard' or section.settings.quick_add == 'overlay' -%}
   <script src="{{ 'quick-add.js' | asset_url }}" defer="defer"></script>
   <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
 {%- endif -%}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -289,8 +289,8 @@
           </div>
         </div>
         {% assign product_form_id = 'quick-add-' | append: section_id | append: card_product.id %}
-        {% if quick_add == 'standard' %}
-          <div class="quick-add no-js-hidden">
+{% if quick_add == 'standard' %}
+  <div class="quick-add no-js-hidden">
             {%- liquid
               assign qty_rules = false
               if card_product.selected_or_first_available_variant.quantity_rule.min > 1 or card_product.selected_or_first_available_variant.quantity_rule.max != null or card_product.selected_or_first_available_variant.quantity_rule.increment > 1
@@ -388,7 +388,96 @@
               </product-form>
             {%- endif -%}
           </div>
-        {% elsif quick_add == 'bulk' %}
+{% elsif quick_add == 'overlay' %}
+  <div class="quick-add quick-add--overlay no-js-hidden">
+    {%- liquid
+      assign qty_rules = false
+      if card_product.selected_or_first_available_variant.quantity_rule.min > 1 or card_product.selected_or_first_available_variant.quantity_rule.max != null or card_product.selected_or_first_available_variant.quantity_rule.increment > 1
+        assign qty_rules = true
+      endif
+    -%}
+    {%- if card_product.variants_count > 1 or qty_rules -%}
+      <modal-opener data-modal="#QuickAdd-{{ card_product.id }}">
+        <button
+          id="{{ product_form_id }}-submit"
+          type="submit"
+          name="add"
+          class="quick-add__submit button button--secondary{% if horizontal_quick_add %} card--horizontal__quick-add animate-arrow{% endif %}"
+          aria-haspopup="dialog"
+          aria-labelledby="{{ product_form_id }}-submit title-{{ section_id }}-{{ card_product.id }}"
+          data-product-url="{{ card_product.url }}"
+        >
+          <span class="visually-hidden">{{ 'products.product.choose_options' | t }}</span>
+          {{ 'icon-cart.svg' | inline_asset_content }}
+          {%- render 'loading-spinner' -%}
+        </button>
+      </modal-opener>
+      <quick-add-modal id="QuickAdd-{{ card_product.id }}" class="quick-add-modal">
+        <div
+          role="dialog"
+          aria-label="{{ 'products.product.choose_product_options' | t: product_name: card_product.title | escape }}"
+          aria-modal="true"
+          class="quick-add-modal__content global-settings-popup"
+          tabindex="-1"
+        >
+          <button
+            id="ModalClose-{{ card_product.id }}"
+            type="button"
+            class="quick-add-modal__toggle"
+            aria-label="{{ 'accessibility.close' | t }}"
+          >
+            {{- 'icon-close.svg' | inline_asset_content -}}
+          </button>
+          <div id="QuickAddInfo-{{ card_product.id }}" class="quick-add-modal__content-info"></div>
+        </div>
+      </quick-add-modal>
+    {%- else -%}
+      <product-form data-section-id="{{ section.id }}">
+        {%- form 'product',
+          card_product,
+          id: product_form_id,
+          class: 'form',
+          novalidate: 'novalidate',
+          data-type: 'add-to-cart-form'
+        -%}
+          <input
+            type="hidden"
+            name="id"
+            value="{{ card_product.selected_or_first_available_variant.id }}"
+            class="product-variant-id"
+            {% if card_product.selected_or_first_available_variant.available == false %}
+              disabled
+            {% endif %}
+          >
+          <button
+            id="{{ product_form_id }}-submit"
+            type="submit"
+            name="add"
+            class="quick-add__submit button button--secondary{% if horizontal_quick_add %} card--horizontal__quick-add{% endif %}"
+            aria-haspopup="dialog"
+            aria-labelledby="{{ product_form_id }}-submit title-{{ section_id }}-{{ card_product.id }}"
+            aria-live="polite"
+            data-sold-out-message="true"
+            {% if card_product.selected_or_first_available_variant.available == false %}
+              disabled
+            {% endif %}
+          >
+            <span class="visually-hidden">
+              {%- if card_product.selected_or_first_available_variant.available -%}
+                {{ 'products.product.add_to_cart' | t }}
+              {%- else -%}
+                {{ 'products.product.sold_out' | t }}
+              {%- endif -%}
+            </span>
+            <span class="sold-out-message hidden">{{ 'products.product.sold_out' | t }}</span>
+            {{ 'icon-cart.svg' | inline_asset_content }}
+            {%- render 'loading-spinner' -%}
+          </button>
+        {%- endform -%}
+      </product-form>
+    {%- endif -%}
+  </div>
+{% elsif quick_add == 'bulk' %}
           {% if card_product.variants_count == 1 %}
             <quick-add-bulk
               data-min="{{ card_product.selected_or_first_available_variant.quantity_rule.min }}"


### PR DESCRIPTION
## Summary
- overlay quick add button over product cards via new `overlay` option
- keep standard quick-add intact
- update sections to load quick-add scripts for overlay mode
- allow locale translations for new overlay option

## Testing
- `prettier -w locales/*.schema.json`


------
https://chatgpt.com/codex/tasks/task_e_688b2cf7ddd48331afbb8a685cfff230