### PR TITLE
Add breadcrumbs to product page

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -74,6 +74,7 @@
 
   {% assign variant_images = product.images | where: 'attached_to_variant?', true | map: 'src' %}
   <div class="page-width">
+    {%- render 'breadcrumb' -%}
     <div class="product product--{{ section.settings.media_size }} product--{{ section.settings.media_position }} product--{{ section.settings.gallery_layout }} product--mobile-{{ section.settings.mobile_thumbnails }} grid grid--1-col {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
       <div class="grid__item product__media-wrapper">
         {% render 'product-media-gallery', variant_images: variant_images %}

--- a/snippets/breadcrumb.liquid
+++ b/snippets/breadcrumb.liquid
@@ -4,8 +4,22 @@
     <li class="breadcrumb__item">
       <a href="{{ routes.root_url }}" class="link">Inicio</a>
     </li>
-    <li class="breadcrumb__item">
-      <span aria-current="page">{{ collection.title }}</span>
-    </li>
+    {% if product %}
+      {% assign breadcrumb_collection = product.collections | first %}
+      {% if breadcrumb_collection %}
+        <li class="breadcrumb__item">
+          <a href="{{ breadcrumb_collection.url }}" class="link">
+            {{ breadcrumb_collection.title }}
+          </a>
+        </li>
+      {% endif %}
+      <li class="breadcrumb__item">
+        <span aria-current="page">{{ product.title }}</span>
+      </li>
+    {% elsif collection %}
+      <li class="breadcrumb__item">
+        <span aria-current="page">{{ collection.title }}</span>
+      </li>
+    {% endif %}
   </ol>
 </nav>


### PR DESCRIPTION
## Summary
- update breadcrumb snippet to support product pages
- show breadcrumb on product page

## Testing
- `theme-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c84df81008331bbabf3754ea73a16