### PR TITLE
Add footer image slider

### DIFF
--- a/assets/footer-slider.js
+++ b/assets/footer-slider.js
@@ -1,0 +1,33 @@
+class AutoSliderComponent extends SliderComponent {
+  constructor() {
+    super();
+    if (!this.slider) return;
+    if (this.slider.dataset.autoplay === 'true') this.setAutoPlay();
+  }
+
+  setAutoPlay() {
+    this.autoplaySpeed = this.slider.dataset.speed * 1000;
+    this.addEventListener('mouseover', this.pause.bind(this));
+    this.addEventListener('mouseleave', this.play.bind(this));
+    this.play();
+  }
+
+  play() {
+    clearInterval(this.autoplay);
+    this.autoplay = setInterval(this.autoRotateSlides.bind(this), this.autoplaySpeed);
+  }
+
+  pause() {
+    clearInterval(this.autoplay);
+  }
+
+  autoRotateSlides() {
+    const position =
+      this.currentPage === this.totalPages
+        ? 0
+        : this.slider.scrollLeft + this.sliderItemOffset;
+    this.setSlidePosition(position);
+  }
+}
+
+customElements.define('auto-slider-component', AutoSliderComponent);

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -31,6 +31,7 @@
     <script src="{{ 'constants.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'pubsub.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'global.js' | asset_url }}" defer="defer"></script>
+    <script src="{{ 'footer-slider.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'details-disclosure.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'details-modal.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'search-form.js' | asset_url }}" defer="defer"></script>

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1017,6 +1017,12 @@
               "default": "<p>Share contact information, store details, and brand content with your customers.</p>"
             }
           }
+        },
+        "slider_image": {
+          "name": "Image slide",
+          "settings": {
+            "image": { "label": "Image" }
+          }
         }
       },
       "settings": {
@@ -1050,6 +1056,10 @@
           "label": "Policy links",
           "info": "[Manage policies](/admin/settings/legal)"
         },
+        "slider_auto_rotate": { "label": "Auto rotate slides" },
+        "slider_speed": { "label": "Change slides every" },
+        "slider_images_desktop": { "label": "Images per view on desktop" },
+        "slider_images_mobile": { "label": "Images per view on mobile" },
         "margin_top": {
           "label": "Top margin"
         },

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -4,6 +4,7 @@
 {{ 'component-list-menu.css' | asset_url | stylesheet_tag }}
 {{ 'component-list-payment.css' | asset_url | stylesheet_tag }}
 {{ 'component-list-social.css' | asset_url | stylesheet_tag }}
+{{ 'component-slider.css' | asset_url | stylesheet_tag }}
 
 {%- style -%}
   .footer {
@@ -250,6 +251,11 @@
     {%- endunless -%}
   {%- endif -%}
 
+  {%- assign slider_blocks = section.blocks | where: 'type', 'slider_image' -%}
+  {%- if slider_blocks.size > 0 -%}
+    {% render 'footer-slider', section: section, slider_blocks: slider_blocks %}
+  {%- endif -%}
+
   <div
     class="footer__content-bottom{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
     {% if settings.animations_reveal_on_scroll %}
@@ -418,7 +424,18 @@
               "label": "Right"
             }
           ],
-          "default": "center"
+        "default": "center"
+      }
+    ]
+    },
+    {
+      "type": "slider_image",
+      "name": "Image slide",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "Image"
         }
       ]
     }
@@ -491,6 +508,44 @@
       "default": true,
       "label": "t:sections.footer.settings.show_policy.label",
       "info": "t:sections.footer.settings.show_policy.info"
+    },
+    {
+      "type": "header",
+      "content": "Image slider"
+    },
+    {
+      "type": "checkbox",
+      "id": "slider_auto_rotate",
+      "default": true,
+      "label": "Auto rotate slides"
+    },
+    {
+      "type": "range",
+      "id": "slider_speed",
+      "min": 3,
+      "max": 9,
+      "step": 1,
+      "unit": "s",
+      "label": "Change slides every",
+      "default": 5
+    },
+    {
+      "type": "range",
+      "id": "slider_images_desktop",
+      "min": 1,
+      "max": 6,
+      "step": 1,
+      "label": "Images per view on desktop",
+      "default": 4
+    },
+    {
+      "type": "range",
+      "id": "slider_images_mobile",
+      "min": 1,
+      "max": 4,
+      "step": 1,
+      "label": "Images per view on mobile",
+      "default": 2
     },
     {
       "type": "header",

--- a/snippets/footer-slider.liquid
+++ b/snippets/footer-slider.liquid
@@ -1,0 +1,65 @@
+{% comment %}
+  Renders an image slider for the footer.
+
+  Accepts:
+  - section: {Object} Footer section object
+  - slider_blocks: {Array} Blocks filtered for slider images
+
+  Usage:
+  {% render 'footer-slider', section: section, slider_blocks: section.blocks | where: 'type', 'slider_image' %}
+{% endcomment %}
+
+<auto-slider-component class="footer-image-slider slider-mobile-gutter">
+  <ul
+    id="FooterSlider-{{ section.id }}"
+    class="slider slider--everywhere grid grid--{{ section.settings.slider_images_desktop }}-col-desktop grid--{{ section.settings.slider_images_mobile }}-col-tablet-down"
+    role="list"
+    data-autoplay="{{ section.settings.slider_auto_rotate }}"
+    data-speed="{{ section.settings.slider_speed }}"
+  >
+    {%- for block in slider_blocks -%}
+      <li
+        id="FooterSlide-{{ section.id }}-{{ forloop.index }}"
+        class="grid__item slider__slide"
+        {{ block.shopify_attributes }}
+      >
+        {%- if block.settings.image != blank -%}
+          {{ block.settings.image | image_url: width: 800 | image_tag: loading: 'lazy' }}
+        {%- else -%}
+          {{ 'image' | placeholder_svg_tag: 'placeholder-svg' }}
+        {%- endif -%}
+      </li>
+    {%- endfor -%}
+  </ul>
+  <div class="slider-buttons">
+    <button
+      type="button"
+      class="slider-button slider-button--prev"
+      name="previous"
+      aria-label="{{ 'general.slider.previous_slide' | t }}"
+      aria-controls="FooterSlider-{{ section.id }}"
+    >
+      <span class="svg-wrapper">{{ 'icon-caret.svg' | inline_asset_content }}</span>
+    </button>
+    <div class="slider-counter slider-counter--dots">
+      {%- for block in slider_blocks -%}
+        <button
+          class="slider-counter__link slider-counter__link--dots link"
+          aria-label="{{ 'general.slider.load_slide' | t }} {{ forloop.index }} {{ 'general.slider.of' | t }} {{ forloop.length }}"
+          aria-controls="FooterSlider-{{ section.id }}"
+        >
+          <span class="dot"></span>
+        </button>
+      {%- endfor -%}
+    </div>
+    <button
+      type="button"
+      class="slider-button slider-button--next"
+      name="next"
+      aria-label="{{ 'general.slider.next_slide' | t }}"
+      aria-controls="FooterSlider-{{ section.id }}"
+    >
+      <span class="svg-wrapper">{{ 'icon-caret.svg' | inline_asset_content }}</span>
+    </button>
+  </div>
+</auto-slider-component>


### PR DESCRIPTION
## Summary
- add `AutoSliderComponent` script to autoplay slider items
- load new script in theme layout
- enable slider styles in footer section
- render configurable image slider within footer
- move footer slider markup into a new `footer-slider` snippet
- add slider settings and block to footer schema
- update English schema translations

## Testing
- `theme-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c84a638788331b8ec22bb54ce00ad