### PR TITLE
Remove footer slider arrows and center indicator

### DIFF
--- a/assets/footer-slider.js
+++ b/assets/footer-slider.js
@@ -6,6 +6,13 @@ class AutoSliderComponent extends SliderComponent {
     this.sliderControlWrapper = this.querySelector('.slider-buttons');
     this.enableSliderLooping = true;
 
+    if (!this.nextButton) {
+      this.initPages();
+      const resizeObserver = new ResizeObserver(() => this.initPages());
+      resizeObserver.observe(this.slider);
+      this.slider.addEventListener('scroll', this.update.bind(this));
+    }
+
     if (this.sliderControlWrapper) {
       this.sliderControlLinksArray = Array.from(
         this.sliderControlWrapper.querySelectorAll('.slider-counter__link')
@@ -15,7 +22,17 @@ class AutoSliderComponent extends SliderComponent {
       );
     }
 
+    this.setInitialSlide();
+
     if (this.slider.dataset.autoplay === 'true') this.setAutoPlay();
+  }
+
+  setInitialSlide() {
+    if (!this.sliderItemOffset || !this.sliderItemsToShow.length) return;
+    this.currentPage = Math.ceil(this.sliderItemsToShow.length / 2);
+    const position = (this.currentPage - 1) * this.sliderItemOffset;
+    this.setSlidePosition(position);
+    this.update();
   }
 
   setAutoPlay() {
@@ -70,10 +87,23 @@ class AutoSliderComponent extends SliderComponent {
   }
 
   update() {
-    super.update();
-    this.sliderControlButtons = this.querySelectorAll('.slider-counter__link');
-    this.prevButton.removeAttribute('disabled');
+    if (!this.slider) return;
 
+    const previousPage = this.currentPage;
+    this.currentPage = Math.round(this.slider.scrollLeft / this.sliderItemOffset) + 1;
+
+    if (this.currentPage != previousPage) {
+      this.dispatchEvent(
+        new CustomEvent('slideChanged', {
+          detail: {
+            currentPage: this.currentPage,
+            currentElement: this.sliderItemsToShow[this.currentPage - 1],
+          },
+        })
+      );
+    }
+
+    this.sliderControlButtons = this.querySelectorAll('.slider-counter__link');
     if (!this.sliderControlButtons.length) return;
 
     this.sliderControlButtons.forEach((link) => {

--- a/snippets/footer-slider.liquid
+++ b/snippets/footer-slider.liquid
@@ -32,15 +32,6 @@
     {%- endfor -%}
   </ul>
   <div class="slider-buttons">
-    <button
-      type="button"
-      class="slider-button slider-button--prev"
-      name="previous"
-      aria-label="{{ 'general.slider.previous_slide' | t }}"
-      aria-controls="Slider-{{ section.id }}"
-    >
-      <span class="svg-wrapper">{{ 'icon-caret.svg' | inline_asset_content }}</span>
-    </button>
     <div class="slider-counter slider-counter--dots">
       {%- for block in slider_blocks -%}
         <button
@@ -52,14 +43,5 @@
         </button>
       {%- endfor -%}
     </div>
-    <button
-      type="button"
-      class="slider-button slider-button--next"
-      name="next"
-      aria-label="{{ 'general.slider.next_slide' | t }}"
-      aria-controls="Slider-{{ section.id }}"
-    >
-      <span class="svg-wrapper">{{ 'icon-caret.svg' | inline_asset_content }}</span>
-    </button>
   </div>
 </auto-slider-component>


### PR DESCRIPTION
## Summary
- drop prev/next arrows from footer slider markup
- center dots on initial slide and handle sliders without arrows

## Testing
- `npm test` *(fails: enoent could not read package.json)*
- `theme-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cdc6ec7348331b47ac0c7c9eddb54