### PR TITLE
Use cart icon for "Seleccionar opciones" button

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -142,6 +142,15 @@ footer footer-slider .slider li img {
 
 .quick-add--overlay .quick-add__submit {
   pointer-events: auto;
+  width: 3rem;
+  min-width: 3rem;
+  height: 3rem;
+  padding: 0;
+  border-radius: 50%;
+  margin-left: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 /* Collections */

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -163,12 +163,8 @@
                   data-product-url="{{ card_product.url }}"
                   onclick="event.stopPropagation()"
                 >
-                  {{ 'products.product.choose_options' | t }}
-                  {%- if horizontal_quick_add -%}
-                    <span class="icon-wrap">
-                      {{- 'icon-arrow.svg' | inline_asset_content -}}
-                    </span>
-                  {%- endif -%}
+                  <span class="visually-hidden">{{ 'products.product.choose_options' | t }}</span>
+                  {{- 'icon-cart.svg' | inline_asset_content -}}
                   {%- render 'loading-spinner' -%}
                 </button>
               </modal-opener>
@@ -440,7 +436,8 @@
                   aria-labelledby="{{ product_form_id }}-submit title-{{ section_id }}-{{ card_product.id }}"
                   data-product-url="{{ card_product.url }}"
                 >
-                  {{ 'products.product.choose_options' | t }}
+                  <span class="visually-hidden">{{ 'products.product.choose_options' | t }}</span>
+                  {{- 'icon-cart.svg' | inline_asset_content -}}
                   {%- render 'loading-spinner' -%}
                 </button>
               </modal-opener>


### PR DESCRIPTION
## Summary
- Replace "Seleccionar opciones" text with cart icon on product cards
- Style quick-add button as a right-aligned round icon

## Testing
- `theme check` *(fails: command not found)*
- `gem install theme-check` *(fails: 403 "Forbidden")*
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d82ba80888331b2e1901161d497ce