### PR TITLE
Make product card images clickable

### DIFF
--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -59,7 +59,8 @@
       >
         {%- if card_product.featured_media -%}
           <div class="card__media{% if image_shape and image_shape != 'default' %} shape--{{ image_shape }} color-{{ settings.card_color_scheme }} gradient{% endif %}">
-            <div class="media media--transparent media--hover-effect">
+            <a href="{{ card_product.url }}" class="full-unstyled-link">
+              <div class="media media--transparent media--hover-effect">
               {% comment %}theme-check-disable ImgLazyLoading{% endcomment %}
               <img
                 srcset="
@@ -103,7 +104,8 @@
                   height="{{ card_product.media[1].height }}"
                 >
               {%- endif -%}
-            </div>
+              </div>
+            </a>
           </div>
         {%- endif -%}
         <div class="card__content">


### PR DESCRIPTION
## Summary
- Wrap product card media in link to product detail page

## Testing
- `npm test` (fails: could not read package.json)
- `theme-check` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a5a608b66c8331b811cfae2cf1786b