### PR TITLE
feat: replace quick-add image with gallery

### DIFF
--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -471,33 +471,11 @@
                     <div class="quick-add__content-info__media">
                       <div class="quick-add__info">
                         {%- if card_product.featured_media -%}
-                          <div
-                            class="quick-add__product-media"
-                          >
-                            <div class="quick-add__product-container global-media-settings">
-                              {% comment %}theme-check-disable ImgLazyLoading{% endcomment %}
-                              <img
-                                srcset="
-                                  {%- if card_product.featured_media.width >= 165 -%}{{ card_product.featured_media | image_url: width: 165 }} 165w,{%- endif -%}
-                                  {%- if card_product.featured_media.width >= 360 -%}{{ card_product.featured_media | image_url: width: 360 }} 360w,{%- endif -%}
-                                  {%- if card_product.featured_media.width >= 533 -%}{{ card_product.featured_media | image_url: width: 533 }} 533w,{%- endif -%}
-                                  {%- if card_product.featured_media.width >= 720 -%}{{ card_product.featured_media | image_url: width: 720 }} 720w,{%- endif -%}
-                                  {%- if card_product.featured_media.width >= 940 -%}{{ card_product.featured_media | image_url: width: 940 }} 940w,{%- endif -%}
-                                  {%- if card_product.featured_media.width >= 1066 -%}{{ card_product.featured_media | image_url: width: 1066 }} 1066w,{%- endif -%}
-                                  {{ card_product.featured_media | image_url }} {{ card_product.featured_media.width }}w
-                                "
-                                src="{{ card_product.featured_media | image_url: width: 533 }}"
-                                sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 130 | divided_by: 4 }}px, (min-width: 990px) calc((100vw - 130px) / 4), (min-width: 750px) calc((100vw - 120px) / 3), calc((100vw - 35px) / 2)"
-                                alt="{{ card_product.featured_media.alt | escape }}"
-                                class="motion-reduce"
-                                {% unless lazy_load == false %}
-                                  loading="lazy"
-                                {% endunless %}
-                                width="{{ card_product.featured_media.width }}"
-                                height="{{ card_product.featured_media.height }}"
-                              >
-                              {% comment %}theme-check-enable ImgLazyLoading{% endcomment %}
-                            </div>
+                          {% assign variant_images = card_product.images | where: 'attached_to_variant?', true | map: 'src' %}
+                          {% assign gallery_section = '{"id": "QuickAdd-' | append: card_product.id | append: '", "settings": {"gallery_layout": "thumbnail_slider", "mobile_thumbnails": "show", "media_size": "small"}}' | parse_json %}
+                          <div class="quick-add__product-media">
+                            <script src="{{ 'media-gallery.js' | asset_url }}" defer="defer"></script>
+                            {% render 'product-media-gallery', product: card_product, variant_images: variant_images, section: gallery_section %}
                           </div>
                         {%- endif -%}
                         <a


### PR DESCRIPTION
## Summary
- replace quick add modal image with full media gallery and thumbnails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b566bd05248331b654f2217fb9c225